### PR TITLE
Types

### DIFF
--- a/src/Types.cpp
+++ b/src/Types.cpp
@@ -12,6 +12,10 @@ Type typeFromString(const std::string& str)
         return Type::eVoid;
     else if (str == "int")
         return Type::eInt;
+    else if (str == "bool")
+        return Type::eBool;
+    else if (str == "int")
+        return Type::eInt;
     else if (str == "array")
         return Type::eArray;
     else


### PR DESCRIPTION
I noticed that the function "typeFromString" allows the parser for void, int, and array deceleration, but in Types.h there are several types allowed. I only added bool to "typeFromString" for a couple reasons.

 It makes sense that func should also be here as well but I was afraid it would break something. My understanding is that "typeFromString" is called by the parser for variable declaration and for function parameters and functions, at least in other languages, can be used in both those ways. Again, didn't do it because it might break something.

I didn't add no_type because it doesnt make sense in the context of var declaration or parameters. Nor did I add undefined for the same reason. That being said, bool is the only one to be added to make it complete